### PR TITLE
Add skill training web mini-game

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Skill Issue Trainer</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div id="app">
+    <div id="menu" class="screen active">
+      <h1>Skill Issue Trainer</h1>
+      <button class="menu-btn" data-mode="click-speed">Click Speed</button>
+      <button class="menu-btn" data-mode="random-aim">Random Aim</button>
+    </div>
+
+    <div id="game" class="screen hidden">
+      <h2 id="game-title"></h2>
+      <div id="game-area"></div>
+      <div id="timer"></div>
+      <div id="score"></div>
+      <div id="goal"></div>
+      <div id="high"></div>
+      <button id="start-btn">Start</button>
+      <button id="back-btn">Back to Menu</button>
+    </div>
+
+    <div id="result" class="screen hidden">
+      <h2>Results</h2>
+      <p id="waifu-comment"></p>
+      <div id="response-options"></div>
+      <p id="waifu-response" class="hidden"></p>
+      <button id="restart-btn">Restart</button>
+      <button id="menu-btn">Menu</button>
+    </div>
+  </div>
+  <script src="script.js"></script>
+</body>
+</html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,169 @@
+const menu = document.getElementById('menu');
+const gameScreen = document.getElementById('game');
+const resultScreen = document.getElementById('result');
+const gameTitle = document.getElementById('game-title');
+const gameArea = document.getElementById('game-area');
+const timerEl = document.getElementById('timer');
+const scoreEl = document.getElementById('score');
+const goalEl = document.getElementById('goal');
+const highEl = document.getElementById('high');
+const startBtn = document.getElementById('start-btn');
+const backBtn = document.getElementById('back-btn');
+const menuBtn = document.getElementById('menu-btn');
+const restartBtn = document.getElementById('restart-btn');
+const waifuComment = document.getElementById('waifu-comment');
+const responseOptions = document.getElementById('response-options');
+const waifuResponse = document.getElementById('waifu-response');
+
+let currentMode = null;
+let score = 0;
+let timer = 0;
+let intervalId = null;
+
+const goalScores = {
+  'click-speed': 30,
+  'random-aim': 20
+};
+
+let highScores = JSON.parse(localStorage.getItem('highScores') || '{}');
+
+function showScreen(screen) {
+  document.querySelectorAll('.screen').forEach(s => s.classList.add('hidden'));
+  screen.classList.remove('hidden');
+  screen.classList.add('active');
+}
+
+function startGame(mode) {
+  currentMode = mode;
+  score = 0;
+  timerEl.textContent = '';
+  scoreEl.textContent = '';
+  gameArea.innerHTML = '';
+  gameTitle.textContent = mode === 'click-speed' ? 'Click Speed' : 'Random Aim';
+  goalEl.textContent = `Goal: ${goalScores[mode]}`;
+  highEl.textContent = `High: ${highScores[mode] || 0}`;
+  showScreen(gameScreen);
+}
+
+function endGame() {
+  clearInterval(intervalId);
+  let high = highScores[currentMode] || 0;
+  if (score > high) {
+    highScores[currentMode] = score;
+    localStorage.setItem('highScores', JSON.stringify(highScores));
+    high = score;
+  }
+
+  const goal = goalScores[currentMode];
+  let comment = '';
+  if (score >= goal) {
+    comment = `Goal achieved! You scored ${score}.`;
+  } else {
+    comment = `You scored ${score}. Goal is ${goal}. Keep practicing!`;
+  }
+  comment += ` High score: ${high}.`;
+
+  waifuComment.textContent = comment;
+
+  responseOptions.innerHTML = '';
+  waifuResponse.classList.add('hidden');
+  waifuResponse.textContent = '';
+  const responses = {
+    simp: 'Senpai! Your clicks make my heart race! ❤',
+    nice: 'Great job out there! Let\'s keep improving together.',
+    troll: 'Pfft, even my grandma clicks faster. Try harder.'
+  };
+
+  Object.entries(responses).forEach(([style, text]) => {
+    const btn = document.createElement('button');
+    btn.textContent = style === 'simp' ? 'Simp' : style === 'nice' ? 'Nice Guy' : 'Troll';
+    btn.addEventListener('click', () => {
+      waifuResponse.textContent = text;
+      waifuResponse.classList.remove('hidden');
+    });
+    responseOptions.appendChild(btn);
+  });
+
+  showScreen(resultScreen);
+}
+
+function runClickSpeed() {
+  const clickBtn = document.createElement('button');
+  clickBtn.textContent = 'Click!';
+  clickBtn.style.fontSize = '24px';
+  gameArea.appendChild(clickBtn);
+  clickBtn.addEventListener('click', () => {
+    score++;
+    scoreEl.textContent = `Score: ${score}`;
+  });
+
+  timer = 5;
+  timerEl.textContent = `Time: ${timer}`;
+  intervalId = setInterval(() => {
+    timer--;
+    timerEl.textContent = `Time: ${timer}`;
+    if (timer <= 0) {
+      endGame();
+    }
+  }, 1000);
+}
+
+function runRandomAim() {
+  timer = 15;
+  timerEl.textContent = `Time: ${timer}`;
+
+  const spawnTarget = () => {
+    gameArea.innerHTML = '';
+    const target = document.createElement('div');
+    target.classList.add('target');
+    target.style.left = Math.random() * (gameArea.clientWidth - 40) + 'px';
+    target.style.top = Math.random() * (gameArea.clientHeight - 40) + 'px';
+    target.addEventListener('click', () => {
+      score++;
+      scoreEl.textContent = `Score: ${score}`;
+      const delay = Math.max(300, 1000 - score * 50);
+      setTimeout(spawnTarget, delay);
+    });
+    gameArea.appendChild(target);
+  };
+
+  spawnTarget();
+
+  intervalId = setInterval(() => {
+    timer--;
+    timerEl.textContent = `Time: ${timer}`;
+    if (timer <= 0) {
+      endGame();
+    }
+  }, 1000);
+}
+
+startBtn.addEventListener('click', () => {
+  if (currentMode === 'click-speed') runClickSpeed();
+  if (currentMode === 'random-aim') runRandomAim();
+  startBtn.classList.add('hidden');
+});
+
+backBtn.addEventListener('click', () => {
+  showScreen(menu);
+});
+
+menuBtn.addEventListener('click', () => {
+  showScreen(menu);
+});
+
+restartBtn.addEventListener('click', () => {
+  showScreen(gameScreen);
+  startBtn.classList.remove('hidden');
+  waifuResponse.classList.add('hidden');
+  waifuResponse.textContent = '';
+  startGame(currentMode);
+});
+
+menu.querySelectorAll('.menu-btn').forEach(btn => {
+  btn.addEventListener('click', () => {
+    startGame(btn.dataset.mode);
+    startBtn.classList.remove('hidden');
+  });
+});
+

--- a/style.css
+++ b/style.css
@@ -1,0 +1,77 @@
+body {
+  font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+  background-color: #1b2838;
+  color: #c7d5e0;
+  margin: 0;
+  text-align: center;
+}
+
+h1, h2 {
+  color: #66c0f4;
+}
+
+.screen {
+  display: none;
+  padding: 20px;
+}
+
+.screen.active {
+  display: block;
+}
+
+.hidden {
+  display: none;
+}
+
+button {
+  background-color: #2a475e;
+  color: #c7d5e0;
+  border: none;
+  padding: 10px 20px;
+  margin: 5px;
+  font-size: 16px;
+  cursor: pointer;
+  transition: background-color 0.3s, transform 0.1s;
+}
+
+button:hover {
+  background-color: #66c0f4;
+  color: #1b2838;
+}
+
+button:active {
+  transform: scale(0.95);
+}
+
+#game-area {
+  position: relative;
+  margin: 20px auto;
+  width: 400px;
+  height: 300px;
+  background-color: #0f1a25;
+  border: 2px solid #66c0f4;
+}
+
+.target {
+  position: absolute;
+  width: 40px;
+  height: 40px;
+  background-color: #66c0f4;
+  border-radius: 50%;
+  cursor: pointer;
+  transition: background-color 0.2s;
+}
+
+.target:hover {
+  background-color: #c7d5e0;
+}
+
+#goal, #high {
+  margin-top: 5px;
+}
+
+#response-options button {
+  display: block;
+  width: 60%;
+  margin: 10px auto;
+}


### PR DESCRIPTION
## Summary
- create web app for training click speed and aiming skills
- add waifu commentary with simp/nice guy/troll responses
- include Steam-inspired styling with goal and high score display

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c149596ef4832685bf08432fe625d3